### PR TITLE
Tm 12048 add different header for first page for address placeholder cb index

### DIFF
--- a/lib/caracal.rb
+++ b/lib/caracal.rb
@@ -46,3 +46,11 @@ Caracal::Core::Models::FooterModel.class_eval do
   include Caracal::Core::Tables
   include Caracal::Core::Text
 end
+
+Caracal::Core::Models::FirstPageFooterModel.class_eval do
+  include Caracal::Core::Images
+  include Caracal::Core::Lists
+  include Caracal::Core::Rules
+  include Caracal::Core::Tables
+  include Caracal::Core::Text
+end

--- a/lib/caracal/core/first_page_footer.rb
+++ b/lib/caracal/core/first_page_footer.rb
@@ -1,0 +1,33 @@
+require 'caracal/core/models/first_page_footer_model'
+require 'caracal/errors'
+
+
+module Caracal
+  module Core
+
+    # This module encapsulates all the functionality related to adding a
+    # footer on only first page of the document.
+    #
+    module FirstPageFooter
+      def self.included(base)
+        base.class_eval do
+
+          #-------------------------------------------------------------
+          # Public Methods
+          #-------------------------------------------------------------
+
+          def first_page_footer(*args, &block)
+            options = Caracal::Utilities.extract_options!(args)
+
+            model = Caracal::Core::Models::FirstPageFooterModel.new(options, &block)
+
+            @first_page_footer_content = model
+
+            model
+          end
+
+        end
+      end
+    end
+  end
+end 

--- a/lib/caracal/core/models/first_page_footer_model.rb
+++ b/lib/caracal/core/models/first_page_footer_model.rb
@@ -1,0 +1,42 @@
+require 'caracal/core/models/base_model'
+require 'caracal/core/models/margin_model'
+require 'caracal/core/models/paragraph_model'
+
+
+module Caracal
+  module Core
+    module Models
+
+      # This class handles block options passed to tables via their data
+      # collections.
+      #
+      class FirstPageFooterModel < BaseModel
+
+        #-------------------------------------------------------------
+        # Configuration
+        #-------------------------------------------------------------
+
+        # initialization
+        def initialize(options={}, &block)
+          super options, &block
+        end
+
+        #-------------------------------------------------------------
+        # Public Methods
+        #-------------------------------------------------------------
+
+        #=============== DATA ACCESSORS =======================
+
+        def contents
+          @contents ||= []
+        end
+
+        #=============== VALIDATION ===========================
+
+        def valid?
+          contents.size > 0
+        end
+      end
+    end
+  end
+end

--- a/lib/caracal/core/models/relationship_model.rb
+++ b/lib/caracal/core/models/relationship_model.rb
@@ -18,7 +18,9 @@ module Caracal
         TYPE_MAP = {
           font:       'http://schemas.openxmlformats.org/officeDocument/2006/relationships/fontTable',
           header:     'http://schemas.openxmlformats.org/officeDocument/2006/relationships/header',
+          first_page_header:    'http://schemas.openxmlformats.org/officeDocument/2006/relationships/header',
           footer:     'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer',
+          first_page_footer:    'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer',
           image:      'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image',
           link:       'http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink',
           numbering:  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering',

--- a/lib/caracal/core/relationships.rb
+++ b/lib/caracal/core/relationships.rb
@@ -27,7 +27,9 @@ module Caracal
             [
               { target: 'fontTable.xml',  type: :font      },
               { target: 'header1.xml',    type: :header    },
+              { target: 'first_page_header.xml',    type: :first_page_header   },
               { target: 'footer1.xml',    type: :footer    },
+              { target: 'first_page_footer.xml',    type: :first_page_footer    },
               { target: 'numbering.xml',  type: :numbering },
               { target: 'settings.xml',   type: :setting   },
               { target: 'styles.xml',     type: :style     }

--- a/lib/caracal/document.rb
+++ b/lib/caracal/document.rb
@@ -6,6 +6,7 @@ require 'caracal/core/custom_properties'
 require 'caracal/core/file_name'
 require 'caracal/core/fonts'
 require 'caracal/core/footer'
+require 'caracal/core/first_page_footer'
 require 'caracal/core/iframes'
 require 'caracal/core/ignorables'
 require 'caracal/core/images'
@@ -28,7 +29,9 @@ require 'caracal/renderers/custom_renderer'
 require 'caracal/renderers/document_renderer'
 require 'caracal/renderers/fonts_renderer'
 require 'caracal/renderers/header_renderer'
+require 'caracal/renderers/first_page_header_renderer'
 require 'caracal/renderers/footer_renderer'
+require 'caracal/renderers/first_page_footer_renderer'
 require 'caracal/renderers/numbering_renderer'
 require 'caracal/renderers/package_relationships_renderer'
 require 'caracal/renderers/relationships_renderer'
@@ -66,6 +69,7 @@ module Caracal
     include Caracal::Core::Text
 
     include Caracal::Core::Footer
+    include Caracal::Core::FirstPageFooter
 
     #------------------------------------------------------
     # Public Class Methods
@@ -97,6 +101,10 @@ module Caracal
 
     def header
       @header ||= Header.new
+    end
+    
+    def first_page_header
+      @first_page_header ||= Header.new
     end
     
     #------------------------------------------------------
@@ -137,6 +145,10 @@ module Caracal
     def footer_content
       @footer_content
     end
+    
+     def first_page_footer_content
+       @first_page_footer_content
+     end
 
     def header_content
       @header_content
@@ -157,12 +169,15 @@ module Caracal
         render_custom(zip)
         render_fonts(zip)
         render_header(zip)
+        render_first_page_header(zip)
         render_footer(zip)
+        render_first_page_footer(zip)
         render_settings(zip)
         render_styles(zip)
         render_document(zip)
         render_relationships(zip)          # Must go here: Depends on document renderer
         render_header_relationships(zip)   # Must go here: Depends on document renderer
+        render_first_page_header_relationships(zip)  # Must go here: Depends on document renderer
         render_media(zip)                  # Must go here: Depends on document renderer
         render_numbering(zip)              # Must go here: Depends on document renderer
       end
@@ -233,6 +248,13 @@ module Caracal
       zip.put_next_entry('word/header1.xml')
       zip.write(content)
     end
+    
+    def render_first_page_header(zip)
+      content = ::Caracal::Renderers::FirstPageHeaderRenderer.render(first_page_header)
+
+      zip.put_next_entry('word/first_page_header.xml')
+      zip.write(content)
+    end
 
     def render_footer(zip)
       content = ::Caracal::Renderers::FooterRenderer.render(self)
@@ -241,6 +263,12 @@ module Caracal
       zip.write(content)
     end
 
+    def render_first_page_footer(zip)
+      content = ::Caracal::Renderers::FirstPageFooterRenderer.render(self)
+
+      zip.put_next_entry('word/first_page_footer.xml')
+      zip.write(content)
+    end
 
     def render_media(zip)
       images = relationships.select { |r| r.relationship_type == :image }
@@ -283,6 +311,15 @@ module Caracal
         content = ::Caracal::Renderers::RelationshipsRenderer.render(header)
 
         zip.put_next_entry('word/_rels/header1.xml.rels')
+        zip.write(content)
+      end
+    end
+    
+    def render_first_page_header_relationships(zip)
+      if first_page_header.relationships.any?
+        content = ::Caracal::Renderers::RelationshipsRenderer.render(first_page_header)
+
+        zip.put_next_entry('word/_rels/first_page_header.xml.rels')
         zip.write(content)
       end
     end

--- a/lib/caracal/renderers/content_types_renderer.rb
+++ b/lib/caracal/renderers/content_types_renderer.rb
@@ -28,7 +28,9 @@ module Caracal
             xml.send 'Override', { 'PartName' => '/docProps/custom.xml', 'ContentType' => 'application/vnd.openxmlformats-officedocument.custom-properties+xml' }
             xml.send 'Override', { 'PartName' => '/word/document.xml',   'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml' }
             xml.send 'Override', { 'PartName' => '/word/footer1.xml',    'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml' }
+            xml.send 'Override', { 'PartName' => '/word/first_page_footer.xml',    'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml' }
             xml.send 'Override', { 'PartName' => '/word/header1.xml',    'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml' }
+            xml.send 'Override', { 'PartName' => '/word/first_page_header.xml',    'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml' }
             xml.send 'Override', { 'PartName' => '/word/fontTable.xml',  'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.fontTable+xml' }
             xml.send 'Override', { 'PartName' => '/word/numbering.xml',  'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml' }
             xml.send 'Override', { 'PartName' => '/word/settings.xml',   'ContentType' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml' }

--- a/lib/caracal/renderers/document_renderer.rb
+++ b/lib/caracal/renderers/document_renderer.rb
@@ -31,11 +31,24 @@ module Caracal
               #============= PAGE SETTINGS ==============================
 
               xml['w'].sectPr do
+                # To display same footer in all the pages of document
                 if rel = document.find_relationship('footer1.xml')
                   xml['w'].footerReference({ 'r:id' => rel.formatted_id, 'w:type' => 'default' })
                 end
+                # To display different footer in first the page of document
+                if rel = document.find_relationship('first_page_footer.xml')
+                  xml['w'].footerReference({ 'r:id' => rel.formatted_id, 'w:type' => 'first' })
+                end
+                
+                # To display same header in all the pages of document
                 if rel = document.find_relationship('header1.xml')
                   xml['w'].headerReference({ 'r:id' => rel.formatted_id, 'w:type' => 'default' })
+                end
+                
+                # To display different header in first the page of document
+                if rel = document.find_relationship('first_page_header.xml')
+                  xml['w'].headerReference({ 'r:id' => rel.formatted_id, 'w:type' => 'first' })
+                  xml['w'].titlePg true
                 end
                 xml['w'].pgSz page_size_options
                 xml['w'].pgMar page_margin_options

--- a/lib/caracal/renderers/first_page_footer_renderer.rb
+++ b/lib/caracal/renderers/first_page_footer_renderer.rb
@@ -1,0 +1,102 @@
+require 'nokogiri'
+
+require 'caracal/renderers/xml_renderer'
+
+
+module Caracal
+  module Renderers
+    class FirstPageFooterRenderer < DocumentRenderer
+
+      #-------------------------------------------------------------
+      # Public Methods
+      #-------------------------------------------------------------
+
+      # This method produces the xml required for the `word/first_page_footer.xml`
+      # sub-document.
+      #
+      def to_xml
+        builder = ::Nokogiri::XML::Builder.with(declaration_xml) do |xml|
+          if document.page_number_show
+            xml['w'].ftr root_options do
+              xml['w'].p paragraph_options do
+                xml['w'].pPr do
+                  xml['w'].contextualSpacing({ 'w:val' => '0' })
+                  xml['w'].jc({ 'w:val' => "#{ document.page_number_align }" })
+                end
+                unless document.page_number_label.nil?
+                  xml['w'].r run_options do
+                    xml['w'].rPr do
+                      xml['w'].rStyle({ 'w:val' => 'PageNumber' })
+                      unless document.page_number_label_size.nil?
+                        xml['w'].sz({ 'w:val'  => document.page_number_label_size })
+                      end
+                    end
+                    xml['w'].t({ 'xml:space' => 'preserve' }) do
+                      xml.text "#{ document.page_number_label } "
+                    end
+                  end
+                end
+                xml['w'].r run_options do
+                  xml['w'].rPr do
+                    unless document.page_number_number_size.nil?
+                      xml['w'].sz({ 'w:val'  => document.page_number_number_size })
+                      xml['w'].szCs({ 'w:val' => document.page_number_number_size })
+                    end
+                  end
+                  xml['w'].fldChar({ 'w:fldCharType' => 'begin' })
+                  xml['w'].instrText({ 'xml:space' => 'preserve' }) do
+                    xml.text 'PAGE'
+                  end
+                  xml['w'].fldChar({ 'w:fldCharType' => 'end' })
+                end
+                xml['w'].r run_options do
+                  xml['w'].rPr do
+                    xml['w'].rtl({ 'w:val' => '0' })
+                  end
+                end
+              end
+            end
+          elsif document.first_page_footer_content.present? && document.first_page_footer_content.valid?
+            xml['w'].ftr root_options do
+
+              #============= CONTENTS ===================================
+
+              document.first_page_footer_content.contents.each do |model|
+                method = render_method_for_model(model)
+                send(method, xml, model)
+              end
+            end
+          end
+        end
+        builder.to_xml(save_options)
+      end
+
+
+      #-------------------------------------------------------------
+      # Private Methods
+      #-------------------------------------------------------------
+      private
+
+      def root_options
+        {
+          'xmlns:mc'  => 'http://schemas.openxmlformats.org/markup-compatibility/2006',
+          'xmlns:o'   => 'urn:schemas-microsoft-com:office:office',
+          'xmlns:r'   => 'http://schemas.openxmlformats.org/officeDocument/2006/relationships',
+          'xmlns:m'   => 'http://schemas.openxmlformats.org/officeDocument/2006/math',
+          'xmlns:v'   => 'urn:schemas-microsoft-com:vml',
+          'xmlns:wp'  => 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing',
+          'xmlns:w10' => 'urn:schemas-microsoft-com:office:word',
+          'xmlns:w'   => 'http://schemas.openxmlformats.org/wordprocessingml/2006/main',
+          'xmlns:wne' => 'http://schemas.microsoft.com/office/word/2006/wordml',
+          'xmlns:sl'  => 'http://schemas.openxmlformats.org/schemaLibrary/2006/main',
+          'xmlns:a'   => 'http://schemas.openxmlformats.org/drawingml/2006/main',
+          'xmlns:pic' => 'http://schemas.openxmlformats.org/drawingml/2006/picture',
+          'xmlns:c'   => 'http://schemas.openxmlformats.org/drawingml/2006/chart',
+          'xmlns:lc'  => 'http://schemas.openxmlformats.org/drawingml/2006/lockedCanvas',
+          'xmlns:dgm' => 'http://schemas.openxmlformats.org/drawingml/2006/diagram'
+        }
+      end
+
+    end
+  end
+end

--- a/lib/caracal/renderers/first_page_header_renderer.rb
+++ b/lib/caracal/renderers/first_page_header_renderer.rb
@@ -1,0 +1,57 @@
+require 'nokogiri'
+require 'caracal/renderers/document_renderer'
+
+
+module Caracal
+  module Renderers
+    class FirstPageHeaderRenderer < DocumentRenderer
+
+      #-------------------------------------------------------------
+      # Public Methods
+      #-------------------------------------------------------------
+
+      # This method produces the xml required for the `word/first_page_header_renderer.xml`
+      # sub-document.
+      #
+      def to_xml
+        builder = ::Nokogiri::XML::Builder.with(declaration_xml) do |xml|
+          xml['w'].hdr header_root_options do
+            document.contents.each do |model|
+              method = render_method_for_model(model)
+              send(method, xml, model)
+            end
+          end
+        end
+        builder.to_xml(save_options)
+      end
+
+      def render_pagebreak(xml, model); end
+
+      #-------------------------------------------------------------
+      # Private Methods
+      #-------------------------------------------------------------
+      private
+
+      def header_root_options
+        {
+          'xmlns:mc'  => 'http://schemas.openxmlformats.org/markup-compatibility/2006',
+          'xmlns:o'   => 'urn:schemas-microsoft-com:office:office',
+          'xmlns:r'   => 'http://schemas.openxmlformats.org/officeDocument/2006/relationships',
+          'xmlns:m'   => 'http://schemas.openxmlformats.org/officeDocument/2006/math',
+          'xmlns:v'   => 'urn:schemas-microsoft-com:vml',
+          'xmlns:wp'  => 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing',
+          'xmlns:w10' => 'urn:schemas-microsoft-com:office:word',
+          'xmlns:w'   => 'http://schemas.openxmlformats.org/wordprocessingml/2006/main',
+          'xmlns:wne' => 'http://schemas.microsoft.com/office/word/2006/wordml',
+          'xmlns:sl'  => 'http://schemas.openxmlformats.org/schemaLibrary/2006/main',
+          'xmlns:a'   => 'http://schemas.openxmlformats.org/drawingml/2006/main',
+          'xmlns:pic' => 'http://schemas.openxmlformats.org/drawingml/2006/picture',
+          'xmlns:c'   => 'http://schemas.openxmlformats.org/drawingml/2006/chart',
+          'xmlns:lc'  => 'http://schemas.openxmlformats.org/drawingml/2006/lockedCanvas',
+          'xmlns:dgm' => 'http://schemas.openxmlformats.org/drawingml/2006/diagram'
+        }
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
In order to support the Different header on the first page of the document in caracal with respect to ticket **TM-12048.**
Added renderers for first-page header and footer as **by default caracal gem does not support multiple headers in a document.**